### PR TITLE
Optimize mint function

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Implementation of ERC721 in Rust for Arbitrum's [Stylus](https://docs.arbitrum.io/stylus/stylus-gentle-introduction).
 Most of the code is based off of the example [here](https://github.com/OffchainLabs/stylus-workshop-nft/blob/main/src/erc712.rs), however there are several differences:
 - Fixed balances bug in the transfer function
+- Optimized mint function to be more gas efficient
 - mint(address) has been changed to mint(address, tokenId). Same goes for safeMint.
 - totalSupply was removed from the base implementation
 - supportsInterface returns true for IERC721Metadata

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Implementation of ERC721 in Rust for Arbitrum's [Stylus](https://docs.arbitrum.i
 Most of the code is based off of the example [here](https://github.com/OffchainLabs/stylus-workshop-nft/blob/main/src/erc712.rs), however there are several differences:
 - Fixed balances bug in the transfer function
 - Optimized mint function to be more gas efficient
+- Optimized safeMint function to be more gas efficient
 - mint(address) has been changed to mint(address, tokenId). Same goes for safeMint.
 - totalSupply was removed from the base implementation
 - supportsInterface returns true for IERC721Metadata

--- a/src/erc721.rs
+++ b/src/erc721.rs
@@ -7,6 +7,8 @@
 //! which allows specifying the name, symbol, and token uri.
 //!
 //! Note that this code is unaudited and not fit for production use.
+//! 
+//! Code is based off the example here: https://github.com/OffchainLabs/stylus-workshop-nft/blob/main/src/erc712.rs
 
 use alloc::{string::String, vec, vec::Vec};
 use alloy_primitives::{Address, U256};
@@ -204,8 +206,8 @@ impl<T: ERC721Params> ERC721<T> {
         token_id: U256,
         data: Vec<u8>,
     ) -> Result<()> {
-        let _ = storage.borrow_mut().mint(to, token_id);
-        let _ = Self::call_receiver(storage, token_id, msg::sender(), to, data);
+        storage.borrow_mut().mint(to, token_id)?;
+        Self::call_receiver(storage, token_id, Address::default(), to, data)?;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,15 +28,24 @@ sol_storage! {
     struct Sample {
         #[borrow] // Allows erc721 to access Sample's storage and make calls
         ERC721<SampleParams> erc721;
+        uint256 total_supply;
     }
 }
 
 #[external]
 #[inherit(ERC721<SampleParams>)]
 impl Sample {
-    /// Mints an NFT
     pub fn mint(&mut self, token_id: U256) -> Result<(), Vec<u8>> {
         self.erc721.mint(msg::sender(), token_id)?;
+        Ok(())
+    }
+
+    pub fn mint_loop(&mut self, qty: U256) -> Result<(), Vec<u8>> {
+        let supply = self.total_supply.get();
+        for i in 0..qty.try_into().unwrap() {
+            self.erc721.mint(msg::sender(), supply + U256::from(i))?;
+        }
+        self.total_supply.set(supply + qty);
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,12 +40,20 @@ impl Sample {
         Ok(())
     }
 
+    pub fn safe_mint(&mut self, token_id: U256) -> Result<(), Vec<u8>> {
+        ERC721::safe_mint(self, msg::sender(), token_id, Vec::new())?;
+        Ok(())
+    }
+
     pub fn mint_loop(&mut self, qty: U256) -> Result<(), Vec<u8>> {
         let supply = self.total_supply.get();
+        let supply: u32 = supply.try_into().unwrap();
+        let qty: u32 = qty.try_into().unwrap();
+    
         for i in 0..qty.try_into().unwrap() {
-            self.erc721.mint(msg::sender(), supply + U256::from(i))?;
+            self.erc721.mint(msg::sender(), U256::from(supply + i))?;
         }
-        self.total_supply.set(supply + qty);
+        self.total_supply.set(U256::from(supply + qty));
         Ok(())
     }
 


### PR DESCRIPTION
The transfer function does a couple unnecessary checks that increase gas usage. We can change the mint function to only increment the `to` balance.